### PR TITLE
Add Spanish locale.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ but it can be modified to work with any API.
 ## Stack Overview
 
 * Ruby version 2.2.0
-* Rails version 4.2.0
+* Rails version 4.2.1
 * Testing Frameworks: MiniTest
 
 ## Local Installation
@@ -106,6 +106,30 @@ replace `ohana-sms-demo` with your actual Heroku app name. Then select
 5. You can now send a different result number to see details about another location.
 
 6. To reset the conversation, send `reset` (it's not case-sensitive).
+
+## Providing the service in multiple languages
+
+Currently, what can be translated are the greetings and instructions.
+The search results content, such as the Location names, or the short
+descriptions, are not translated. In order to translate search results,
+you would need to sign up for Google's paid translation service, but I
+have not integrated it in this app yet.
+
+To translate the greetings and instructions, copy and paste the contents of
+`config/locales/en.yml` into a new file in `config/locales` with a filename
+corresponding to the language's two-character code, and with a `.yml`
+extension. Then translate the text from English into your desired language.
+See `config/locales/es.yml` as an example. For more details, read the
+[Rails Internationalization Guide](http://guides.rubyonrails.org/i18n.html).
+
+Once your translations are in place, create a new number in your Twilio account
+that will be used for a particular language. Following the same instructions
+as in Step 7 in the [Deploy to Heroku section](#deploy-to-heroku), add `?locale=[language_code]` to
+the end of the Request URL. For example, to make your phone number use Spanish,
+your Request URL would look like this:
+```
+https://ohana-sms-demo.herokuapp.com/locations/reply?locale=es
+```
 
 ## Running the tests
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,6 @@
 class LocationsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :set_locale
 
   def reply
     session[:counter] ||= 0
@@ -10,5 +11,11 @@ class LocationsController < ApplicationController
 
     session[:counter] += 1
     render xml: twiml.text
+  end
+
+  private
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/services/conversation_tracker.rb
+++ b/app/services/conversation_tracker.rb
@@ -32,6 +32,7 @@ class ConversationTracker
   end
 
   def process_category_choice
+    @session[:cats] = @body
     return apologize_and_restart if no_results?
     enable_third_step
     Messenger.new(@session).search_results
@@ -49,7 +50,6 @@ class ConversationTracker
   def enable_third_step
     @session[:step_2] = false
     @session[:step_3] = true
-    @session[:cats] = @body
   end
 
   def third_step_message

--- a/app/services/messenger.rb
+++ b/app/services/messenger.rb
@@ -22,7 +22,11 @@ class Messenger
   end
 
   def categories_list
-    cat_array.map.with_index { |cat, i| "##{i + 1}: #{cat}" }.join(', ')
+    localized_cats.map.with_index { |cat, i| "##{i + 1}: #{cat}" }.join(', ')
+  end
+
+  def localized_cats
+    I18n.t('categories')
   end
 
   def cat_array
@@ -62,11 +66,11 @@ class Messenger
   end
 
   def phone
-    "Phone: #{location.phones.first.number}"
+    "#{I18n.t('phone')}: #{location.phones.first.number}"
   end
 
   def address
-    "Address: #{street_address}"
+    "#{I18n.t('address')}: #{street_address}"
   end
 
   def street_address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,17 @@ en:
   no_results_found: >
     Sorry, no results found. Please try again with a different ZIP code or
     category.
+  phone: Phone
+  address: Address
+  categories:
+  - Care
+  - Education
+  - Emergency
+  - Food
+  - Goods
+  - Health
+  - Housing
+  - Legal
+  - Money
+  - Transit
+  - Work

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,27 @@
+es:
+  intro: >
+    Bienvenidos a SMC-Connect! Por favor, escriba un código postal de 5 dígitos para empezar.
+  choose_category: 'Por favor, elija una categoría escribiendo su número: %{list}'
+  invalid_category: 'Por favor, escriba un número entre 1 y 11.'
+  results_intro: >
+    Aquí hay hasta 5 lugares que coinciden con su búsqueda.
+    Para obtener más detalles sobre un lugar, ingresar el número.
+  choose_location: >
+    Para obtener más información sobre otra ubicación, escriba un número entre 1 y 5.
+    Para volver a empezar, escriba "reset".
+  you_are_welcome: "De nada!"
+  no_results_found: 'Lo sentimos, no hay resultados. Inténtalo de nuevo con un código postal diferente o categoría.'
+  phone: Fon
+  address: Dirección
+  categories:
+  - Asistencia
+  - Educación
+  - Emergencia
+  - Comida
+  - Bienes
+  - Salud
+  - Viviendas
+  - Legal
+  - Dinero
+  - Tránsito
+  - Trabajo

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,17 +12,17 @@
 
 default: &default
   categories:
-    - Care
-    - Education
-    - Emergency
-    - Food
-    - Goods
-    - Health
-    - Housing
-    - Legal
-    - Money
-    - Transit
-    - Work
+  - Care
+  - Education
+  - Emergency
+  - Food
+  - Goods
+  - Health
+  - Housing
+  - Legal
+  - Money
+  - Transit
+  - Work
 
 development:
   <<: *default

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -103,10 +103,10 @@ class LocationsControllerTest < ActionController::TestCase
     assert_equal true, session[:step_3]
   end
 
-  test 'sets session[:cats] to body when category is 1-11' do
-    get_reply_with_body('94103')
-    get_reply_with_body('2')
-    assert_equal '2', session[:cats]
+  test 'sets session[:cats] to body before making API request' do
+    get_reply_with_body('94388')
+    get_reply_with_body('11')
+    assert_equal '11', session[:cats]
   end
 
   test 'sets session[:step_2] to false when category is 1-11' do
@@ -253,9 +253,25 @@ class LocationsControllerTest < ActionController::TestCase
     assert_equal t('intro'), sms_body
   end
 
+  test 'uses Spanish when locale params is set to es' do
+    get_reply_with_body('', 'es')
+    assert_match(/Bienvenidos/, sms_body)
+    get_reply_with_body('94103', 'es')
+    assert_match(/elija una categoría/, sms_body)
+    get_reply_with_body('8', 'es')
+    assert_match(/Aquí hay hasta/, sms_body)
+  end
+
+  test 'uses English category names for API search' do
+    get_reply_with_body('', 'es')
+    get_reply_with_body('94103', 'es')
+    get_reply_with_body('1', 'es')
+    assert_match(/Aquí hay hasta/, sms_body)
+  end
+
   private
 
-  def get_reply_with_body(body)
-    get :reply, 'Body' => body
+  def get_reply_with_body(body, locale = 'en')
+    get :reply, 'Body' => body, locale: locale
   end
 end


### PR DESCRIPTION
I think the easiest way to use a different locale is to use a separate Twilio number for each language.

In your Twilio configuration, add the appropriate locale at the end of the Request URL. For example, for Spanish, do this:

https://ohana-sms-demo.herokuapp.com/locations/reply?locale=es