### PR TITLE
Check for specific value to validate requests

### DIFF
--- a/app/controllers/concerns/twilio_request_validator.rb
+++ b/app/controllers/concerns/twilio_request_validator.rb
@@ -35,6 +35,6 @@ module TwilioRequestValidator
   private
 
   def validations_enabled?
-    Figaro.env.VALIDATE_REQUEST
+    Figaro.env.VALIDATE_REQUEST == 'true'
   end
 end


### PR DESCRIPTION
**Why**: Because setting it to `’false’` would also make `validations_enabled?` return `true`.